### PR TITLE
setoptコマンドを使ってzshのオプションを変更する

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -55,3 +55,6 @@ eval "$(direnv hook zsh)"
 
 # hubの設定
 eval "$(hub alias -s)"
+
+# zsh: no matches found: を防ぐ
+setopt nonomatch


### PR DESCRIPTION
## やったこと

- setoptコマンドを使ってzshのオプションを変更する

## とくに見て欲しいところ

- 特になし

## 動作確認したこと

- curlのコマンドを実行してエラーにならないこと